### PR TITLE
Improve performance

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,16 +1,19 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        org.clojure/tools.logging {:mvn/version "1.2.4"}
-        org.slf4j/slf4j-api {:mvn/version "2.0.11"}}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
+        org.clojure/tools.logging {:mvn/version "1.3.0"}
+        org.slf4j/slf4j-api {:mvn/version "2.0.12"}}
 
  :aliases {:dev {:extra-paths ["dev-resources"]
                  :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
                             "-Duser.timezone=UTC"
                             "-Dfile.encoding=UTF-8"]
-                 :extra-deps {org.slf4j/jcl-over-slf4j {:mvn/version "2.0.11"}
-                              ch.qos.logback/logback-classic {:mvn/version "1.4.14"
+                 :extra-deps {org.slf4j/jcl-over-slf4j {:mvn/version "2.0.12"}
+                              ch.qos.logback/logback-classic {:mvn/version "1.5.3"
                                                               :exclusions [org.slf4j/slf4j-api]}
                               net.logstash.logback/logstash-logback-encoder {:mvn/version "7.4"}}}
+           :dev/repl {:main-opts ["-m" "clojure.main"]
+                      :extra-paths ["dev-resources"]
+                      :extra-deps {nrepl/nrepl {:mvn/version "1.1.1"}}}
 
            :test {:main-opts ["-m" "kaocha.runner"]
                   :extra-paths ["dev-resources" "test"]
@@ -23,8 +26,9 @@
                                   "-Duser.timezone=UTC"
                                   "-Dfile.encoding=UTF-8"]
                        :paths ["src" "bench"]
-                       :extra-deps {criterium/criterium {:mvn/version "0.4.6"}}}
+                       :extra-deps {criterium/criterium {:mvn/version "0.4.6"}
+                                    org.slf4j/slf4j-nop {:mvn/version "2.0.12"}}}
 
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.0"}
                           slipset/deps-deploy {:mvn/version "0.2.2"}}
                    :ns-default build}}}

--- a/dev-resources/logback-test.xml
+++ b/dev-resources/logback-test.xml
@@ -8,9 +8,11 @@
 
   <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+      <!-- <includeCallerData>true</includeCallerData> -->
       <fieldNames>
         <timestamp>timestamp</timestamp>
         <version>[ignore]</version>
+        <levelValue>[ignore]</levelValue>
       </fieldNames>
     </encoder>
   </appender>


### PR DESCRIPTION


before changes:

```
 #'mokujin.log-bench/mokujin-log-all : 1.763753 µs
 #'mokujin.log-bench/tools-logging-log-all : 118.916261 ns
 #'mokujin.log-bench/tools-logging+context : 749.481706 ns
```

Latest benchmark:

```
 #'mokujin.log-bench/mokujin-log-all : 787.695659 ns
 #'mokujin.log-bench/tools-logging-log-all : 121.793190 ns
 #'mokujin.log-bench/tools-logging+context : 445.952752 ns

```