### PR TITLE
Api revamp: make context the last argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/.cpcache/**
 **/.lsp/**
 target
+*.html

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ processing you can expect a small slow down but still maintain sub-microsecond p
 your typical usage - most of applications running out there do a lot of I/O, where processing times are measured in milliseconds
 or seconds event, so any overhead introduced by logging is negligble.
 
-You can run the benchmark via `clj -M:benchmark`. Latest results (as of March 18th 2024):
+You can run the benchmark via `clj -M:benchmark`. Latest results (as of April 9th, 2024):
 
 ```
-#'mokujin.log-bench/mokujin-log : 121.436908 ns
-#'mokujin.log-bench/mokujin-log+context : 886.954250 ns
-#'mokujin.log-bench/tools-logging-log : 132.977819 ns
-#'mokujin.log-bench/tools-logging-log+context : 538.664454 ns
+#'mokujin.log-bench/mokujin-log : 121.528074 ns
+#'mokujin.log-bench/mokujin-log+context : 614.801815 ns
+#'mokujin.log-bench/tools-logging-log : 127.343391 ns
+#'mokujin.log-bench/tools-logging-log+context : 383.410334 ns
 ```
 
 > [!INFO]

--- a/bench/mokujin/log_bench.clj
+++ b/bench/mokujin/log_bench.clj
@@ -6,14 +6,14 @@
 (set! *warn-on-reflection* true)
 
 (defn mokujin-log+context []
-  (log/info {:some "context"} "hello")
+  (log/info "hello" {:some "context"})
   (log/info "no context")
   (log/with-context {"some" "ctx"}
     (log/with-context {:nested "true"}
       (log/warn "hello")
       (log/infof "hello %s" "world")
       (log/info "nested"))
-    (log/error {:error "yes"} (ex-info "oh no" {:exc :data}) "oh no"))
+    (log/error (ex-info "oh no" {:exc :data}) "oh no" {:error "yes"}))
   true)
 
 (defn mokujin-log []
@@ -23,7 +23,6 @@
   (log/infof "nested %s=%s" :some "context")
   (log/errorf (ex-info "oh no" {:exc :data}) "oh no %s=%s" :error "yes")
   true)
-
 
 (defn tools-logging-log []
   (logging/infof "hello %s=%s" :some "context")

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
                             "-Duser.timezone=UTC"
                             "-Dfile.encoding=UTF-8"]
                  :extra-deps {org.slf4j/jcl-over-slf4j {:mvn/version "2.0.12"}
-                              ch.qos.logback/logback-classic {:mvn/version "1.5.3"
+                              ch.qos.logback/logback-classic {:mvn/version "1.5.4"
                                                               :exclusions [org.slf4j/slf4j-api]}
                               net.logstash.logback/logstash-logback-encoder {:mvn/version "7.4"}}}
            :dev/repl {:main-opts ["-m" "clojure.main"]
@@ -18,8 +18,8 @@
            :test {:main-opts ["-m" "kaocha.runner"]
                   :extra-paths ["dev-resources" "test"]
 
-                  :extra-deps {cheshire/cheshire {:mvn/version "5.12.0"}
-                               lambdaisland/kaocha {:mvn/version "1.87.1366"}}}
+                  :extra-deps {cheshire/cheshire {:mvn/version "5.13.0"}
+                               lambdaisland/kaocha {:mvn/version "1.88.1376"}}}
 
            :benchmark {:main-opts ["-m" "mokujin.log-bench"]
                        :jvm-opts ["-XX:-OmitStackTraceInFastThrow"

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
-        org.slf4j/slf4j-api {:mvn/version "2.0.12"}}
+        org.slf4j/slf4j-api {:mvn/version "2.0.12"}
+        org.clojure/data.xml {:mvn/version "0.2.0-alpha9"}}
 
  :aliases {:dev {:extra-paths ["dev-resources"]
                  :jvm-opts ["-XX:-OmitStackTraceInFastThrow"

--- a/examples/log4j2/core.clj
+++ b/examples/log4j2/core.clj
@@ -3,7 +3,7 @@
 
 (defn -main
   [& _args]
-  (log/info {:some "context"} "hello")
+  (log/info "hello" {:some "context"})
   (log/info "no context")
   (log/with-context {"some" "ctx"}
     (log/with-context {:nested "true"}
@@ -11,5 +11,5 @@
       (log/infof "hello %s" "world")
       (log/info "nested"))
 
-    (log/error {:error "yes"} (ex-info "oh no" {:exc :data}) "oh no"))
+    (log/error (ex-info "oh no" {:exc :data}) "oh no" {:error "yes"}))
   true)

--- a/examples/log4j2/deps.edn
+++ b/examples/log4j2/deps.edn
@@ -11,4 +11,4 @@
 
  :aliases {:run {:main-opts ["-m" "core"]}
            :stable {:extra-deps
-                    {org.clojars.lukaszkorecki/mokujin {:mvn/version "1.0.0.39"}}}}}
+                    {org.clojars.lukaszkorecki/mokujin {:mvn/version "1.0.0.44"}}}}}

--- a/examples/logback/core.clj
+++ b/examples/logback/core.clj
@@ -3,7 +3,7 @@
 
 (defn -main
   [& _args]
-  (log/info {:some "context"} "hello")
+  (log/info "hello" {:some "context"})
   (log/info "no context")
   (log/with-context {"some" "ctx"}
     (log/with-context {:nested "true"}
@@ -11,5 +11,5 @@
       (log/infof "hello %s" "world")
       (log/info "nested"))
 
-    (log/error {:error "yes"} (ex-info "oh no" {:exc :data}) "oh no"))
+    (log/error (ex-info "oh no" {:exc :data}) "oh no" {:error "yes"}))
   true)

--- a/examples/logback/deps.edn
+++ b/examples/logback/deps.edn
@@ -2,10 +2,10 @@
  :main-opts ["-m" "core"]
  :deps {mokujin/mokujin {:local/root "../../"}
         org.slf4j/jcl-over-slf4j {:mvn/version "2.0.12"}
-        ch.qos.logback/logback-classic {:mvn/version "1.5.3"
+        ch.qos.logback/logback-classic {:mvn/version "1.5.4"
                                         :exclusions [org.slf4j/slf4j-api]}
         net.logstash.logback/logstash-logback-encoder {:mvn/version "7.4"}}
 
  :aliases {:run {:main-opts ["-m" "core"]}
            :stable {:extra-deps
-                    {org.clojars.lukaszkorecki/mokujin {:mvn/version "1.0.0.39"}}}}}
+                    {org.clojars.lukaszkorecki/mokujin {:mvn/version "1.0.0.44"}}}}}

--- a/src/mokujin/log.clj
+++ b/src/mokujin/log.clj
@@ -130,11 +130,12 @@
 ;; Re-export generic log functions but with context support
 ;; NOTE: these are SLOWER than dedicated log macros
 (defmacro log
+  "Log wrapper which is helpful if you need to programatically control the log level"
   ([level msg]
    (with-meta
      `(log/log ~level ~msg)
      (meta &form)))
-  ([level msg context? & _rest]
+  ([level msg context?]
    (with-meta
      `(cond
         (and (string? ~msg)
@@ -145,7 +146,9 @@
              (not (map? ~context?))) (log/log ~level ~msg))
      (meta &form))))
 
-(defmacro logf [level msg & args]
+(defmacro logf
+  "Log wrapper which is helpful if you need to programatically control the log level."
+  [level msg & args]
   (with-meta
     `(log/logf ~level ~msg ~@args)
     (meta &form)))

--- a/src/mokujin/log.clj
+++ b/src/mokujin/log.clj
@@ -54,7 +54,7 @@
    (with-meta
      `(log/log :info ~msg)
      (meta &form)))
-  ([ctx msg]
+  ([msg ctx]
    (with-meta
      `(with-context ~ctx
         (log/log :info ~msg))
@@ -66,7 +66,7 @@
    (with-meta
      `(log/log :warn ~msg)
      (meta &form)))
-  ([ctx msg]
+  ([msg ctx]
    (with-meta
      `(with-context ~ctx
         (log/log :warn ~msg))
@@ -78,7 +78,7 @@
    (with-meta
      `(log/log :debug ~msg)
      (meta &form)))
-  ([ctx msg]
+  ([msg ctx]
    (with-meta
      `(with-context ~ctx
         (log/log :debug ~msg))
@@ -99,9 +99,9 @@
    (with-meta
      `(log/log :error ~exc ~msg)
      (meta &form)))
-  ([ctx exc msg]
+  ([exc msg ctx]
    (with-meta
-     `(with-context ~ctx
+     `(with-context ~ctx #_ (merge ~ctx (ex-data ~exc)) ;; XXX: should we merge ex-data here?
         (log/log :error ~exc ~msg))
      (meta &form))))
 

--- a/src/mokujin/logback.clj
+++ b/src/mokujin/logback.clj
@@ -1,0 +1,94 @@
+(ns mokujin.logback
+  "Configures logback using supplied config or config file.
+  Inspired by https://github.com/pyr/unilog by doesn't try to hide any
+  of the Logback configuration, it just provides a way to configure it at runtime and optionally with EDN data.
+  "
+  (:require
+   [clojure.data.xml :as xml])
+  (:import
+   [ch.qos.logback.classic Logger LoggerContext Level]
+   [ch.qos.logback.classic.joran JoranConfigurator]
+   [java.io ByteArrayInputStream InputStream]
+   [org.slf4j LoggerFactory]))
+
+(defn config-data->xml-str [config]
+  (->> config
+       (xml/sexps-as-fragment)
+       ;; NOTE: we can use indent-str here to make it more readable as perf doesn't matter
+       (xml/indent-str)))
+
+(defn str->input-stream [^String s]
+  (ByteArrayInputStream. (.getBytes s)))
+
+(defn- get-named-logger-and-context [logger-name]
+  (let [logger-context ^LoggerContext (LoggerFactory/getILoggerFactory)
+        logger (.getLogger logger-context ^String logger-name)]
+    {:logger logger :logger-context logger-context}))
+
+(defn- initialize-and-configure! [config-stream]
+  (let [{:keys [logger logger-context]} (get-named-logger-and-context Logger/ROOT_LOGGER_NAME)
+        configurator ^JoranConfigurator (JoranConfigurator.)]
+    (.detachAndStopAllAppenders ^Logger logger)
+    (.reset ^LoggerContext logger-context)
+    (.setContext configurator ^LoggerContext logger-context)
+    (.doConfigure configurator ^InputStream config-stream)))
+
+(defn configure!
+  "Configure logback with the given configuration.
+  One of the keys nees to be present:
+  `xml-config-path` - path or resource to the logback configuration file, it will
+                      override any loaded loback configuration found
+                      in <classpath>/logback.xml or <classpath>/logback-test.xml
+  `config` - a map with logback configuration, as hiccup-style EDN data eg.
+
+  ```clojure
+  [:configuration
+     [:statusListener {:class \"ch.qos.logback.core.status.NopStatusListener\"}]
+     [:appender {:name \"STDOUT\", :class \"ch.qos.logback.core.ConsoleAppender\"}
+       [:encoder
+         [:pattern \"%date [%thread] [%logger] [%level] %msg %mdc%n\"]]]
+     [:appender {:name \"STDOUT_JSON\", :class \"ch.qos.logback.core.ConsoleAppender\"}
+       [:encoder {:class \"net.logstash.logback.encoder.LogstashEncoder\"}
+         [:fieldNames
+           [:timestamp \"timestamp\"]
+           [:version \"[ignore]\"]
+           [:levelValue \"[ignore]\"]]]]
+     [:root {:level \"info\"}
+       [:appender-ref {:ref \"STDOUT_JSON\"}]]]
+
+  ```
+  Note that it will not do any transformations to the configuration, so it needs to be in the correct format,
+  internally `clojure.data.xml/sexps-as-fragment` is used to convert the hiccup-style EDN data to XML.
+  "
+  [{:keys [config]}]
+  (cond
+    ;; clj data -> xml
+    (vector? config) (with-open [conf ^java.io.Closeable (str->input-stream (config-data->xml-str config))]
+                       (initialize-and-configure! conf))
+    ;; "raw" XML string
+    (string? config) (with-open [conf ^java.io.Closeable (str->input-stream config)]
+                       (initialize-and-configure! conf))
+    ;; io/resource most likely?
+    (instance? java.net.URL config) (with-open [conf ^java.io.Closeable (.openStream ^java.net.URL config)]
+                                      (initialize-and-configure! conf))
+    :else (ex-info "Uknown configuration type" {:config config :class (class config)})))
+
+(def levels
+  {:all Level/ALL
+   :off Level/OFF
+   :info Level/INFO
+   :debug Level/DEBUG
+   :warn Level/WARN
+   :error Level/ERROR
+   :trace Level/TRACE})
+
+(defn set-level!
+  "Set logging level dynamically - can be used to change logging level at runtime
+  If only level (a kewyord of the levels map) is provided, it will set the level for the root logger
+  if name and level are provided, it will set the level for the named logger.
+  "
+  ([level]
+   (set-level! Logger/ROOT_LOGGER_NAME level))
+  ([name level]
+   (let [{:keys [logger]} (get-named-logger-and-context name)]
+     (.setLevel ^Logger logger ^Level (get levels level :info)))))

--- a/src/mokujin/logback/config.clj
+++ b/src/mokujin/logback/config.clj
@@ -1,0 +1,89 @@
+(ns mokujin.logback.config
+  (:require
+   [clojure.data.xml :as xml]))
+
+(defn data->xml-str [config]
+  (->> config
+       (xml/sexps-as-fragment)
+       ;; NOTE: we can use indent-str here to make it more readable as perf doesn't matter
+       (xml/indent-str)))
+
+(defn json
+  "Creates a logback configuration with JSON output.
+  Optionally takes a list of loggers to add to the configuration e.g
+
+  ```clojure
+  [:logger {:name \"com.example\" :level \"debug\"}]
+  [:logger {:name \"org.eclipse.jetty\" :level \"warn\"}]
+  "
+  [& loggers]
+  (data->xml-str
+   [:configuration
+
+    [:status-listener {:class "ch.qos.logback.core.status.NopStatusListener"}]
+
+    [:appender {:name "STDOUT_JSON", :class "ch.qos.logback.core.ConsoleAppender"}
+
+     [:encoder {:class "net.logstash.logback.encoder.LogstashEncoder"}
+      [:throwableConverter {:class "net.logstash.logback.stacktrace.ShortenedThrowableConverter"}
+       [:shortenedClassNameLength 25]]
+
+      [:fieldNames
+       [:timestamp "timestamp"]
+       [:version "[ignore]"]
+       [:levelValue "[ignore"]]]]
+
+    loggers
+
+    [:root {:level "info"}
+     [:appender-ref {:ref "STDOUT_JSON"}]]]))
+
+(defn json-async [& loggers]
+  (data->xml-str
+   [:configuration
+    ;; First, JSON appender logging to STDOUT
+    [:appender {:name "STDOUT_JSON", :class "ch.qos.logback.core.ConsoleAppender"}
+     [:encoder {:class "net.logstash.logback.encoder.LogstashEncoder"}
+      [:throwableConverter {:class "net.logstash.logback.stacktrace.ShortenedThrowableConverter"}
+       [:shortenedClassNameLength 25]]
+
+      [:fieldNames
+       [:timestamp "timestamp"]
+       [:version "[ignore]"]
+       [:levelValue "[ignore"]]]]
+
+    ;; now pipe STDOUT_JSON to the ASYNC appender
+    [:appender {:name "ASYNC", :class "ch.qos.logback.classic.AsyncAppender"}
+     [:appender-ref {:ref "STDOUT_JSON"}]
+     [:queueSize 4096]
+     [:discardingThreshold 0]]
+
+    loggers
+
+    [:root {:level "info"}
+     [:appender-ref {:ref "ASYNC"}]]]))
+
+(defn text
+  "Creates a logback configuration with plain text output and MDC.
+
+  Optionally takes a list of loggers to add to the configuration e.g
+
+  ```clojure
+  [:logger {:name \"com.example\" :level \"debug\"}]
+  [:logger {:name \"org.eclipse.jetty\" :level \"warn\"}]
+  ```
+  "
+
+  [& loggers]
+  (data->xml-str
+   [:configuration
+    [:status-listener {:class "ch.qos.logback.core.status.NopStatusListener"}]
+    [:appender {:name "STDOUT", :class "ch.qos.logback.core.ConsoleAppender"}
+
+     [:encoder
+
+      [:pattern "%date [%thread]   [%logger] [%level] %msg %mdc%n"]]
+     loggers
+
+     [:root {:level "info"}
+      [:appender-ref {:ref "STDOUT"}]]]]))

--- a/test/mokujin/log_test.clj
+++ b/test/mokujin/log_test.clj
@@ -51,7 +51,7 @@
 
   (testing "with context"
     (log/with-context {:foo "bar"}
-      (log/info {:bar "baz"} "ahem")
+      (log/info "ahem" {:bar "baz"})
       (is (= "bar" (MDC/get "foo")))
 
       (is (= {"foo" "bar"} (log/current-context)))))
@@ -77,7 +77,7 @@
   (testing "init state"
     (is (nil? (MDC/get "foo"))))
   (try
-    (log/info {:foo "bar"} (format "%s" (throw (Exception. "foo"))))
+    (log/info (format "%s" (throw (Exception. "foo"))) {:foo "bar"})
     (catch Exception _err
       (is (= {} (log/current-context)))
       (testing "after catch"
@@ -93,7 +93,7 @@
      (fn nested' []
        (log/with-context {:level-one "yes"}
          (log/with-context {:level-two "yes"}
-           (log/info {:level-three "yes"} "ahem"))))))
+           (log/info "ahem" {:level-three "yes"}))))))
 
   (let [captured-logs (parse-captured-logs)]
     (testing "contexts can be nested, but only work within current thread"
@@ -130,7 +130,7 @@
   (run-in-thread (fn structured' []
                    (log/info "one")
                    (log/with-context {:nested true}
-                     (log/warn {:foo "bar"} "two"))
+                     (log/warn "two" {:foo "bar"}))
                    (log/error "three")
                    (log/with-context {:nested "again"}
                      (log/with-context {:foo "bar"}
@@ -140,7 +140,7 @@
                        (try
                          (throw (ex-info "this is exception" {}))
                          (catch Exception e
-                           (log/error {:fail true} e "six")))))
+                           (log/error e "six" {:fail true})))))
                    (log/info "seven")))
   (let [captured-logs (map #(dissoc % :logger_name :thread_name)
                            (parse-captured-logs))]
@@ -176,7 +176,7 @@
                                                     (log/with-context {:nested true}
                                                       (log/info "bar")
                                                       (log/with-context {:nested "for real"}
-                                                        (log/warn {:foo "bar"} "qux")))))
+                                                        (log/warn "qux" {:foo "bar"})))))
 
                          #(run-in-thread "test-2" (fn []
                                                     (log/with-context {:foo "bar2"}
@@ -184,7 +184,7 @@
                                                       (try
                                                         (assert false)
                                                         (catch AssertionError e
-                                                          (log/error {:fail true} e "oh no again again"))))))]))))
+                                                          (log/error e "oh no again again" {:fail true}))))))]))))
 
   (let [captured-logs (parse-captured-logs)]
     (is (= [{:level "INFO"


### PR DESCRIPTION
This will make it compose better, and straighten out `log/error` usage.