### PR TITLE
Feature/reorganize internal api  linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,7 @@ test-ex-log4j2:
 
 benchmark:
 	cd bench && clj -M:benchmark
+
+
+help:
+	@grep -E '^[a-z]+:' ./Makefile

--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 
 > Mokujin (木人 Wooden person?) is a character in the Tekken series of fighting games. It is a spiritually sensitive animated training dummy, and serves as a guardian of good against supernatural evil threats. Mokujin is made of logs, hence the name.
 
-
-
 [![Clojars Project](https://img.shields.io/clojars/v/org.clojars.lukaszkorecki/mokujin.svg)](https://clojars.org/org.clojars.lukaszkorecki/mokujin)
 [![Clojars Project](https://img.shields.io/clojars/v/org.clojars.lukaszkorecki/mokujin-logback.svg)](https://clojars.org/org.clojars.lukaszkorecki/mokujin-logback)
-
 
 
 > [!WARNING]
@@ -98,10 +95,29 @@ Macbook M4 Pro.
 
 ## API & Usage
 
-The API is close enough that Mokujin is *almost* a drop-in replacement for `c.t.logging`, **however** to force good practices,
-logging functions that support format strings e.g. `log/infof` or `log/errorf` **do not support the context map**.
-That's because in 99% of the cases where I'd use `log/infof` what I wanted to do was `(log/info "message" context)` instead.
+### Full API
 
+```clojure
+(log/info [msg] [msg ctx])
+(log/warn [msg] [msg ctx])
+(log/debug [msg] [msg ctx])
+(log/trace [msg] [msg ctx])
+(log/error [msg] [exc msg] [exc msg ctx])
+(log/infof [fmt & fmt-args])
+(log/warnf [fmt & fmt-args])
+(log/debugf [fmt & fmt-args])
+(log/tracef [fmt & fmt-args])
+(log/errorf [fmt & fmt-args])
+(log/with-context [ctx & body])
+```
+
+Just like `clojure.tools.logging`, Mokujin preserves caller context, and ensures that the right
+information (namespace, line numbers) is injected into the log statement, under the `logger` field.
+
+The API is close enough that Mokujin is *almost* a drop-in replacement for `c.t.logging`, **however** to promote good practices, and
+maintain good performance logging functions that support format strings e.g. `log/infof` or `log/errorf` **do not support the context map** as input.
+
+That's because in 99% of the cases where I'd use `log/infof` what I wanted to do was `(log/info "message" context)` instead.
 In cases where you really really want to use formatted strings and the context, this Works Just Fine :tm: :
 
 ```clojure
@@ -181,24 +197,6 @@ To work around this, you can use `log/with-context` to wrap the form that needs 
       (log/info "hi!")))) ;; will have the context
 ```
 
-
-### Full API
-
-#### Logging statements
-
-```clojure
-(log/info [msg] [msg ctx])
-(log/warn [msg] [msg ctx])
-(log/debug [msg] [msg ctx])
-(log/error [msg] [exc msg] [exc msg ctx])
-(log/infof [fmt & fmt-args])
-(log/warnf [fmt & fmt-args])
-(log/debugf [fmt & fmt-args])
-(log/errorf [fmt & fmt-args])
-(log/with-context [ctx & body])
-```
-
-Mokujin preserves caller context, and ensures that the right information (namespace, line numbers) is injected into the log statement, under the `logger` field.
 
 ## Setup
 

--- a/examples/lint/core.clj
+++ b/examples/lint/core.clj
@@ -1,0 +1,30 @@
+#_{:clj-kondo/ignore [:namespace-name-mismatch]}
+(ns linting
+  (:require [mokujin.log :as log]))
+
+(log/info "don't run me :-)")
+(System/exit 0)
+
+;; valid
+(log/info "foobar" {:test 1})
+
+;; invalid
+(log/info {:msg "test"} "bananas")
+
+;;  invalid
+(log/error 'foo "bar" {:test 1})
+
+
+(try
+  (/ 1 0)
+  (catch Exception err
+    ;; valid
+    (log/errorf err "woah %s" "bananas")))
+
+;; invalid
+
+(log/errorf {:foo "bar"} "bananas")
+
+
+;; valid
+(log/error "oh no")

--- a/examples/lint/deps.edn
+++ b/examples/lint/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["."]
+ :main-opts ["-m" "core"]
+ :deps {org.clojars.lukaszkorecki/mokujin {:local/root "../../mokujin"}}}

--- a/examples/logback/core.clj
+++ b/examples/logback/core.clj
@@ -1,6 +1,5 @@
 (ns core
-  (:require [mokujin.log :as log]
-            [mokujin.logback :as logback]))
+  (:require [mokujin.log :as log]))
 
 (defn -main
   [& _args]

--- a/mokujin/deps.edn
+++ b/mokujin/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.slf4j/slf4j-api {:mvn/version "2.0.17"}}

--- a/mokujin/resources/clj-kondo.exports/org.clojars.lukaszkorecki/mokujin/config.edn
+++ b/mokujin/resources/clj-kondo.exports/org.clojars.lukaszkorecki/mokujin/config.edn
@@ -1,0 +1,20 @@
+{:hooks {:analyze-call {mokujin.log/info hooks.log-lint/log-args
+                        mokujin.log/warn hooks.log-lint/log-args
+                        mokujin.log/trace hooks.log-lint/log-args
+                        mokujin.log/debug hooks.log-lint/log-args
+
+                        mokujin.log/infof hooks.log-lint/logf-args
+                        mokujin.log/warnf hooks.log-lint/logf-args
+                        mokujin.log/tracef hooks.log-lint/logf-args
+                        mokujin.log/debugf hooks.log-lint/logf-args
+
+                        mokujin.log/error hooks.log-lint/error-log-args
+                        mokujin.log/errorf hooks.log-lint/log-errof-args}}
+
+ :linters {:redundant-ignore {:exclude [:clojure-lsp/unused-public-var]}
+           :mokujin.log/error-log-too-many-args {:level :error}
+           :mokujin.log/log-statement-too-many-arguments {:level :error}
+           :mokujin.log/error-log-context-not-supported {:level :warning}
+           :mokujin.log/error-log-map-args {:level :warning}
+           :mokujin.log/log-message-not-string {:level :warning}
+           :mokujin.log/log-context-not-map {:level :warning}}}

--- a/mokujin/resources/clj-kondo.exports/org.clojars.lukaszkorecki/mokujin/hooks/log_lint.clj
+++ b/mokujin/resources/clj-kondo.exports/org.clojars.lukaszkorecki/mokujin/hooks/log_lint.clj
@@ -1,0 +1,78 @@
+(ns hooks.log-lint
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn register! [node msg context]
+  (api/reg-finding! (-> (meta node)
+                        (assoc :message msg)
+                        (merge context))))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var :redundant-ignore]}
+(defn error-log-args
+  "Verifies that log/error can be only called with one or two args:
+  (log/error exc msg)
+  (log/error msg)"
+  [{:keys [node]}]
+  (let [sexpr (api/sexpr node)
+        arg-count (count (rest sexpr))
+        [arg1 arg2 & _] (rest sexpr)]
+    (cond
+      ;; error only accepts [throwable msg] or [msg] as args, so anything more than that is not valid
+      (>= arg-count 3)
+      (register! node "too many arguments passed to log/error" {:type :mokujin.log/invalid-arg-count})
+
+      ;; we have two args but first is a string, indicates that 2nd arg is a context
+      (and (= arg-count 2)
+           (string? arg1))
+      (register! node "log/error doesn't accept context maps as 2nd argument!" {:type :mokujin.log/error-log-context-not-supported})
+
+      (or (map? arg1) (map? arg2))
+      (register! node "log/error doesn't accept maps as log statements" {:type :mokujin.log/error-log-map-args}))))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var :redundant-ignore]}
+(defn log-args
+  "generic log dispatch for info, warn, debug log calls which accept the following:
+  (log/info msg-str)
+  (log/info msg-str context-map)"
+  [{:keys [node]}]
+  (let [sexpr (rest (api/sexpr node))
+        [msg? ctx? & _rest?] sexpr]
+    (cond
+      (>= (count sexpr) 3) (register! node "too many arguments" {:type :mokujin.log/invalid-arg-count})
+      (not (string? msg?)) (register! node "log message is not a string" {:type :mokujin.log/log-message-not-string})
+      (and (= 2 (count sexpr)) (not (map? ctx?))) (register! node "log context is not a map" {:type :mokujin.log/log-context-not-map}))))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var :redundant-ignore]}
+(defn logf-args
+  "Verifies that *f variants never accepts a context map as 2nd argument and have varargs"
+  [{:keys [node]}]
+
+  (let [sexpr (api/sexpr node)
+        arg-count (count (rest sexpr))
+        [arg1 _arg2 & _] (rest sexpr)]
+    (cond
+      (= arg-count 1)
+      (register! node "too few arguments passed to logf" {:type :mokujin.log/invalid-arg-count})
+
+      (not (string? arg1))
+      (register! node "log message is not a string" {:type :mokujin.log/log-message-not-string}))))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn log-errof-args
+  "like `logf-args` but issues a warning if the first argument is not a string"
+  [{:keys [node]}]
+  (let [sexpr (api/sexpr node)
+        arg-count (count (rest sexpr))
+        [arg1 arg2 & _] (rest sexpr)]
+    (cond
+      (= arg-count 1)
+      (register! node "too few arguments passed to errorf" {:type :mokujin.log/invalid-arg-count})
+
+      (and
+        (= arg-count 2)
+        (not (string? arg1)))
+      (register! node "too few arguments passed to errorf" {:type :mokujin.log/invalid-arg-count})
+
+      (and (>= arg-count 3)
+           (not (string? arg1))
+           (not (string? arg2)))
+      (register! node (format "log message is not a string %s" [arg1 arg2]) {:type :mokujin.log/log-message-not-string}))))

--- a/mokujin/test/mokujin/log_test.clj
+++ b/mokujin/test/mokujin/log_test.clj
@@ -73,10 +73,11 @@
   (testing "after"
     (is (nil? (MDC/get "foo")))))
 
-(deftest mdcs-doesnt-spill-over-on-error-in-message
+(deftest mdc-doesnt-persist-after-error-in-log-statement
   (testing "init state"
     (is (nil? (MDC/get "foo"))))
   (try
+    #_{:clj-kondo/ignore [:mokujin.log/log-message-not-string]}
     (log/info (format "%s" (throw (Exception. "foo"))) {:foo "bar"})
     (catch Exception _err
       (is (= {} (log/current-context)))
@@ -222,11 +223,6 @@
              :stack_trace {:count 4 :message "java.lang.AssertionError: Assert failed: false"}
              :thread_name "test-2"}]
            (filter #(= (:thread_name %) "test-2") captured-logs)))))
-
-(deftest timer-test
-  (let [get-run-time (log/timer)]
-    (Thread/sleep 100)
-    (is (>= (get-run-time) 100))))
 
 (deftest generic-log-marco-test
   (testing "`log` macro"


### PR DESCRIPTION
Adds linters to catch common issues. All linters are warnings only, since `clj-kondo` cannot truly figure out if something is a string or not, e.g.

```clojure
(let [msg (format "woah %s" :there)]
  (log/info msg))
```

is valid, but not recommended.


Also:

- `trace` & `tracef` is added
- removed `timer` util, not the right place for this