### PR TITLE
Feature: context flattener

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ;; pass a context map to add structured data to the message
 (log/info "hi!" {:foo "bar" :baz "qux"})
 
-;; context can be set 
+;; context can be set
 (log/with-context {:action "vibe-check"}
   (log/debug "checking the vibes")
   (let [are-you-ok? (do-the-vibe-check)]
@@ -70,7 +70,7 @@ Second part of ensuring that right things are logged and we keep a good performa
 
 ### How does it work?
 
-Mokujin wraps `clojure.tools.logging` and injects SLF4J's MDC into logging events, if provided. 
+Mokujin wraps `clojure.tools.logging` and injects SLF4J's MDC into logging events, if provided.
 Keep in mind that `infof` (and friends) variants are present, but do not support passing the MDC (more on that later).
 
 
@@ -84,13 +84,13 @@ processing you can expect a small slow down but still maintain sub-microsecond p
 your typical usage - most of applications running out there do a lot of I/O, where processing times are measured in milliseconds
 or seconds even, so any overhead introduced by logging is negligble.
 
-You can run the benchmark via `clj -M:benchmark`. Latest results (as of 30/03/2025) run on my M4 MBP Pro are:
+You can run the benchmark via `clj -M:benchmark`. Latest results (as of 19/08/2025) run on my M4 MBP Pro + Java 24 + Clojure 1.12.1:
 
 ```
-#'mokujin.log-bench/mokujin-log : 76.876114 ns
-#'mokujin.log-bench/mokujin-log+context : 346.391248 ns
-#'mokujin.log-bench/tools-logging-log : 78.078607 ns
-#'mokujin.log-bench/tools-logging-log+context : 221.394879 ns
+#'mokujin.log-bench/mokujin-log : 38.617807 ns
+#'mokujin.log-bench/mokujin-log+context : 182.073844 ns
+#'mokujin.log-bench/tools-logging-log : 39.924598 ns
+#'mokujin.log-bench/tools-logging-log+context : 104.985398 ns
 ```
 
 > [!NOTE]
@@ -138,7 +138,7 @@ Second difference is that only 1- and 2-arity (or in case of `log/error` 3-arity
 (log/info "hello" "there" "world")
 ```
 
-To help with migration and good log hygine Mokujin ships with custom hooks for `clj-kondo` and 
+To help with migration and good log hygine Mokujin ships with custom hooks for `clj-kondo` and
 report warnings in case of suspicious or incompatible call styles are detected.
 
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,8 @@ Second part of ensuring that right things are logged and we keep a good performa
 
 ### How does it work?
 
-Mokujin wraps `clojure.tools.logging` and inject SLF4J's MDC into logging events, if provided. It tries to maintain a balance between new
-features and the API of a widely used library. Mokujin wraps standard logging macros (`info`, `warn` etc) and adds
-support for the context map argument, as the first argument.
+Mokujin wraps `clojure.tools.logging` and injects SLF4J's MDC into logging events, if provided. Mokujin wraps standard logging macros (`info`, `warn` etc)
+and adds support for the context map argument, as the last argument.
 
 Keep in mind that `infof` (and friends) variants are present, but do not support passing the MDC (more on that later).
 
@@ -77,7 +76,7 @@ processing you can expect a small slow down but still maintain sub-microsecond p
 your typical usage - most of applications running out there do a lot of I/O, where processing times are measured in milliseconds
 or seconds even, so any overhead introduced by logging is negligble.
 
-You can run the benchmark via `clj -M:benchmark`. Latest results (as of 30/03/2025) are:
+You can run the benchmark via `clj -M:benchmark`. Latest results (as of 30/03/2025) run on my M4 MBP are:
 
 ```
 #'mokujin.log-bench/mokujin-log : 76.876114 ns
@@ -86,9 +85,7 @@ You can run the benchmark via `clj -M:benchmark`. Latest results (as of 30/03/20
 #'mokujin.log-bench/tools-logging-log+context : 221.394879 ns
 ```
 
-Macbook M4 Pro.
-
-> [!INFO]
+> [!NOTE]
 > Benchmarks are tricky, and always should be taken with a grain of salt.
 > My sole focus with these is to ensure that Mokujin keeps up with `tools.logging` as far as performance is concerned.
 > There's many more variables that need to be taken into account when measuring performance impact of logs in your application.

--- a/bench/deps.edn
+++ b/bench/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["."]
  :deps {org.clojars.lukaszkorecki/mokujin {:local/root "../mokujin"}
         criterium/criterium {:mvn/version "0.4.6"}
-        org.slf4j/slf4j-nop {:mvn/version "2.0.16"}}
+        org.slf4j/slf4j-nop {:mvn/version "2.0.17"}}
  :aliases {:benchmark {:main-opts ["-m" "mokujin.log-bench"]
                        :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
                                   "-Duser.timezone=UTC"

--- a/bench/mokujin/log_bench.clj
+++ b/bench/mokujin/log_bench.clj
@@ -1,5 +1,6 @@
 (ns mokujin.log-bench
   (:require [mokujin.log :as log]
+            [mokujin.context.format :as ctx.fmt]
             [clojure.tools.logging :as logging]
             [criterium.core :as criterium]))
 
@@ -42,7 +43,31 @@
   (logging/errorf (ex-info "oh no" {:exc :data}) "oh no %s=%s" :error "yes")
   true)
 
+(defn mokujin-log+context+flattener []
+  (binding [log/*context-formatter* ctx.fmt/flatten]
+    (log/with-context {:some "ctx" :a {:b :1} :z [{:foo "bar"} {:bar "baz"}]}
+      (log/infof "hello %s=%s" :some "context")
+      (log/info "no contgext")
+      (log/with-context {:other "aha"}
+        (log/warnf "hello %s=%s %s=%s" :some "context" :nested "true"))
+      (log/infof "nested %s=%s" :some "context"))))
+
+(defn tools-logging-log+context+flattener []
+  (binding [log/*context-formatter* ctx.fmt/flatten]
+    (log/with-context {:some "ctx" :a {:b :1} :z [{:foo "bar"} {:bar "baz"}]}
+      (logging/infof "hello %s=%s" :some "context")
+      (logging/info "no contgext")
+      (log/with-context {:other "aha"}
+        (logging/warnf "hello %s=%s %s=%s" :some "context" :nested "true"))
+      (logging/infof "nested %s=%s" :some "context"))))
+
 (defn -main []
-  (doseq [f [#'mokujin-log #'mokujin-log+context #'tools-logging-log #'tools-logging-log+context]]
+  (doseq [f [#'mokujin-log
+             #'mokujin-log+context
+             #'tools-logging-log
+             #'tools-logging-log+context
+             #'mokujin-log+context+flattener
+             #'tools-logging-log+context+flattener]]
+
     (let [result (criterium/quick-benchmark* f {})]
       (criterium/report-point-estimate (str f) (:mean result)))))

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 ;; this top-level dependency file is only for jar builds & deploys
 ;; each project contains it's own deps.edn
 {:paths []
- :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}
+ :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}
                           slipset/deps-deploy {:mvn/version "0.2.2"}}
                    :ns-default build}}}

--- a/examples/log4j2/deps.edn
+++ b/examples/log4j2/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["." "resources"]
  :deps {mokujin/mokujin {:local/root "../../mokujin"}
 
-        org.apache.logging.log4j/log4j-1.2-api {:mvn/version "2.24.3"}
-        org.apache.logging.log4j/log4j-api {:mvn/version "2.24.3"}
-        org.apache.logging.log4j/log4j-core {:mvn/version "2.24.3"}
-        org.apache.logging.log4j/log4j-jcl {:mvn/version "2.24.3"}
-        org.apache.logging.log4j/log4j-jul {:mvn/version "2.24.3"}
+        org.apache.logging.log4j/log4j-1.2-api {:mvn/version "2.25.1"}
+        org.apache.logging.log4j/log4j-api {:mvn/version "2.25.1"}
+        org.apache.logging.log4j/log4j-core {:mvn/version "2.25.1"}
+        org.apache.logging.log4j/log4j-jcl {:mvn/version "2.25.1"}
+        org.apache.logging.log4j/log4j-jul {:mvn/version "2.25.1"}
         org.apache.logging.log4j/log4j-slf4j2-impl
-        {:mvn/version "2.24.3"}}
+        {:mvn/version "2.25.1"}}
 
  :aliases {:run {:main-opts ["-m" "core"]}
            :stable {:extra-deps

--- a/mokujin-logback/deps.edn
+++ b/mokujin-logback/deps.edn
@@ -17,6 +17,6 @@
 
            :run-tests {:main-opts ["-m" "kaocha.runner"]}
 
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}
                           slipset/deps-deploy {:mvn/version "0.2.2"}}
                    :ns-default build}}}

--- a/mokujin-logback/deps.edn
+++ b/mokujin-logback/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/data.xml {:mvn/version "0.2.0-alpha9"}
         ch.qos.logback/logback-classic {:mvn/version "1.5.18"
                                         :exclusions [org.slf4j/slf4j-api]}
-        net.logstash.logback/logstash-logback-encoder {:mvn/version "8.0"}}
+        net.logstash.logback/logstash-logback-encoder {:mvn/version "8.1"}}
 
  :aliases {:dev {:extra-paths ["dev-resources"]
                  :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
@@ -18,9 +18,9 @@
            :test {:main-opts ["-m" "kaocha.runner"]
                   :extra-paths ["dev-resources" "test"]
 
-                  :extra-deps {cheshire/cheshire {:mvn/version "5.13.0"}
+                  :extra-deps {cheshire/cheshire {:mvn/version "6.0.0"}
                                lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
 
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}
                           slipset/deps-deploy {:mvn/version "0.2.2"}}
                    :ns-default build}}}

--- a/mokujin/deps.edn
+++ b/mokujin/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.1"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.slf4j/slf4j-api {:mvn/version "2.0.17"}}
 
@@ -17,6 +17,6 @@
 
            :run-tests {:main-opts ["-m" "kaocha.runner"]}
 
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}
                           slipset/deps-deploy {:mvn/version "0.2.2"}}
                    :ns-default build}}}

--- a/mokujin/deps.edn
+++ b/mokujin/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.1"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
         org.slf4j/slf4j-api {:mvn/version "2.0.17"}}
 
@@ -16,10 +16,10 @@
            :test {:main-opts ["-m" "kaocha.runner"]
                   :extra-paths ["dev-resources" "test"]
 
-                  :extra-deps {cheshire/cheshire {:mvn/version "5.13.0"}
+                  :extra-deps {cheshire/cheshire {:mvn/version "6.0.0"}
                                lambdaisland/kaocha {:mvn/version "1.91.1392"}
                                org.clojars.lukaszkorecki/mokujin-logback {:local/root "../mokujin-logback"}}}
 
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.8"}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}
                           slipset/deps-deploy {:mvn/version "0.2.2"}}
                    :ns-default build}}}

--- a/mokujin/resources/clj-kondo.exports/org.clojars.lukaszkorecki/mokujin/hooks/log_lint.clj
+++ b/mokujin/resources/clj-kondo.exports/org.clojars.lukaszkorecki/mokujin/hooks/log_lint.clj
@@ -16,8 +16,8 @@
         arg-count (count (rest sexpr))
         [arg1 arg2 & _] (rest sexpr)]
     (cond
-      ;; error only accepts [throwable msg] or [msg] as args, so anything more than that is not valid
-      (>= arg-count 3)
+      ;; error only accepts [msg], [throwable msg] [throwable msg ctx] as args, so anything more than that is not valid
+      (> arg-count 3)
       (register! node "too many arguments passed to log/error" {:type :mokujin.log/invalid-arg-count})
 
       ;; we have two args but first is a string, indicates that 2nd arg is a context

--- a/mokujin/src/mokujin/context/format.clj
+++ b/mokujin/src/mokujin/context/format.clj
@@ -8,17 +8,19 @@
 
 (defn- ->str
   [val] ^String
-  (case val
-    nil "null"
-    false "false"
-    #_else (if (keyword? val)
-             ;; all of these are quite slow
-             #_(.replaceAll ^String (.getName ^clojure.lang.Keyword val) "-" "_")
-             #_(.replaceAll ^String (str (symbol val)) "-" "_")
-             #_(.getName ^clojure.lang.Keyword val)
-             ;; fastest way to get a fully-quallified keyword as a string
-             (str (symbol val))
-             (Object/.toString val))))
+
+  (if val
+    (if (keyword? val)
+      ;; all of these are quite slow
+      #_(.replaceAll ^String (.getName ^clojure.lang.Keyword val) "-" "_")
+      #_(.replaceAll ^String (str (symbol val)) "-" "_")
+      #_(.getName ^clojure.lang.Keyword val)
+      ;; fastest way to get a fully-quallified keyword as a string
+      (str (symbol val))
+      (Object/.toString val))
+    (case val
+      nil "null"
+      false "false")))
 
 (defn stringify
   "Given context map `ctx`, returns a new map with all keys and values converted to strings,

--- a/mokujin/src/mokujin/context/format.clj
+++ b/mokujin/src/mokujin/context/format.clj
@@ -1,0 +1,52 @@
+(ns mokujin.context.format
+  (:refer-clojure :exclude [flatten])
+  (:require [clojure.string :as str]))
+
+(defn- ->str
+  [val] ^String
+  (if val
+    (if (keyword? val)
+      ;; all of these are quite slow
+      #_(.replaceAll ^String (.getName ^clojure.lang.Keyword val) "-" "_")
+      #_(.replaceAll ^String (str (symbol val)) "-" "_")
+      #_(.getName ^clojure.lang.Keyword val)
+      ;; fastest way to get a fully-quallified keyword as a string
+      (str (symbol val))
+      (.toString ^Object val))
+    ""))
+
+(defn stringify
+  "Given context map `ctx`, returns a new map with all keys and values converted to strings,
+  this also means that any netsed data structures will be stringified as well, and most likely very
+  hard to parse when using structured data appender like JSON."
+  [ctx]
+  (persistent!
+   (reduce-kv (fn [m k v]
+                (assoc! m (->str k) (->str v)))
+              (transient {})
+              ctx)))
+
+(defn flatten
+  "Given a context map it will 'flatten' it, i.e. convert all nested maps and collections into a single map and
+  keys will be strings with dot notation, e.g. `:a.b.c` for nested map `{:a {:b {:c 1}}}`.
+
+  Collections will be addressed by key paths with indexes eg `:a.0.b.c` for `{:a [{:b {:c 1}}]}`.
+
+  NOTE: this is quite slower than default `stringify` formatter. Use it only if you can take the perf hit and
+  still have addressable context map keys. "
+  [ctx]
+
+  (letfn [(flatten-impl [m prefix]
+            (reduce-kv (fn [acc k v]
+                         (let [new-key (if prefix
+                                         (str prefix "." (->str k))
+                                         (->str k))]
+                           (cond
+                             (map? v) (merge acc (flatten-impl v new-key))
+                             (coll? v) (reduce-kv
+                                        (fn [a i e] (merge a {(str new-key "." i) e}))
+                                        acc v)
+                             :else (assoc acc new-key v))))
+                       {}
+                       m))]
+    (flatten-impl ctx nil)))

--- a/mokujin/src/mokujin/context/format.clj
+++ b/mokujin/src/mokujin/context/format.clj
@@ -1,19 +1,23 @@
 (ns mokujin.context.format
   (:refer-clojure :exclude [flatten])
   (:require [clojure.string :as str]))
+(set! *warn-on-reflection* true)
+
+(def ^:private l {nil "null" false "false"})
 
 (defn- ->str
   [val] ^String
-  (if val
-    (if (keyword? val)
-      ;; all of these are quite slow
-      #_(.replaceAll ^String (.getName ^clojure.lang.Keyword val) "-" "_")
-      #_(.replaceAll ^String (str (symbol val)) "-" "_")
-      #_(.getName ^clojure.lang.Keyword val)
-      ;; fastest way to get a fully-quallified keyword as a string
-      (str (symbol val))
-      (.toString ^Object val))
-    ""))
+  (case val
+    nil "null"
+    false "false"
+    #_else (if (keyword? val)
+             ;; all of these are quite slow
+             #_(.replaceAll ^String (.getName ^clojure.lang.Keyword val) "-" "_")
+             #_(.replaceAll ^String (str (symbol val)) "-" "_")
+             #_(.getName ^clojure.lang.Keyword val)
+             ;; fastest way to get a fully-quallified keyword as a string
+             (str (symbol val))
+             (Object/.toString val))))
 
 (defn stringify
   "Given context map `ctx`, returns a new map with all keys and values converted to strings,

--- a/mokujin/src/mokujin/log.clj
+++ b/mokujin/src/mokujin/log.clj
@@ -5,7 +5,23 @@
   (:import
    (org.slf4j MDC)))
 
+(set! *warn-on-reflection* true)
+
 (def ^:dynamic *context-formatter* ctx.fmt/stringify)
+
+(def formatters
+  {::default ctx.fmt/stringify
+   ::stringify ctx.fmt/stringify
+   ::flatten ctx.fmt/flatten})
+
+(defn set-context-formatter!
+  "Set the context formatter to use for `with-context` and `mdc-put`.
+  The formatter should be a function that takes a context map and returns a new map with stringified keys and values."
+  [formatter]
+  (if-let [fmt (formatters formatter)]
+    (alter-var-root #'*context-formatter* (constantly fmt))
+    (throw (IllegalArgumentException.
+            (str "Unknown context formatter: " formatter " Valid options are: " (keys formatters))))))
 
 ;; TODO: use binding for context?
 (defn mdc-put

--- a/mokujin/test/mokujin/context/format_test.clj
+++ b/mokujin/test/mokujin/context/format_test.clj
@@ -9,7 +9,7 @@
   (testing "simple case with string keys"
     (is (= {"a" "b"} (ctx.fmt/stringify {"a" "b"}))))
 
-  (testing "keyword handling, including namespaced kws"
+  (testing "keyword handling including namespaced kws"
     (is (= {"a" "b" "c/d" "e"} (ctx.fmt/stringify {:a :b :c/d :e})))
     (is (= {"a/b" "c/d"} (ctx.fmt/stringify {:a/b :c/d})))
     (is (= {"a.b/c" "d.e/f"} (ctx.fmt/stringify {:a.b/c :d.e/f}))))
@@ -22,9 +22,37 @@
     (is (= {"a" "1"} (ctx.fmt/stringify {:a 1})))
     (is (= {"a" "true"} (ctx.fmt/stringify {:a true})))
     (is (= {"a" "null"} (ctx.fmt/stringify {:a nil})))
-    (is (= {"t" "true" "f" "false"} (ctx.fmt/stringify {:t true :f false })))
+    (is (= {"t" "true" "f" "false"} (ctx.fmt/stringify {:t true :f false})))
     (is (= {"a" "Sun Oct 01 12:00:00 UTC 2023"}
            (ctx.fmt/stringify {:a #inst "2023-10-01T12:00:00Z"})))
 
     (is (= {"huh" "clojure.lang.ExceptionInfo: woah {:a 1, :b 2}"}
            (ctx.fmt/stringify {:huh (ex-info "woah" {:a 1 :b 2})})))))
+
+(deftest flatten-test
+  (testing "works just like stringify for simple maps"
+    (is (= {"a" "b"} (ctx.fmt/flatten {:a "b"})))
+    (is (= {} (ctx.fmt/flatten {})))
+
+    (is (= {"q" "false" "r" "string" "x" "1" "y" "true" "z" "null"}
+           (ctx.fmt/stringify {:x 1 :y true :z nil :q false :r "string"})
+           (ctx.fmt/flatten {:x 1 :y true :z nil :q false :r "string"}))))
+
+  (testing "nested maps"
+
+    (is (= {"a.b" "c" "a.d.e" "f"}
+           (ctx.fmt/flatten {:a {:b "c" :d {:e "f"}}})))
+
+    (is (= {"a.b.c" "d" "a.e.f.g" "h"}
+           (ctx.fmt/flatten {:a {:b {:c "d"} :e {:f {:g "h"}}}}))))
+
+  (testing "nested collections"
+    (is (= {"a.0.b" "c" "a.1.d.e" "f"}
+           (ctx.fmt/flatten {:a [{:b "c"} {:d {:e "f"}}]})))
+
+    (is (= {"a.0.b.c" "d" "a.1.e.f.g" "h"}
+           (ctx.fmt/flatten {:a [{:b {:c "d"}} {:e {:f {:g "h"}}}]}))))
+
+  (testing "edge case with sets - these won't be handled"
+    (is (= {"a" (pr-str #{1 2 3})}
+           (ctx.fmt/flatten {:a #{1 2 3}})))))

--- a/mokujin/test/mokujin/context/format_test.clj
+++ b/mokujin/test/mokujin/context/format_test.clj
@@ -21,7 +21,8 @@
   (testing "other data types"
     (is (= {"a" "1"} (ctx.fmt/stringify {:a 1})))
     (is (= {"a" "true"} (ctx.fmt/stringify {:a true})))
-    (is (= {"a" ""} (ctx.fmt/stringify {:a nil})))
+    (is (= {"a" "null"} (ctx.fmt/stringify {:a nil})))
+    (is (= {"t" "true" "f" "false"} (ctx.fmt/stringify {:t true :f false })))
     (is (= {"a" "Sun Oct 01 12:00:00 UTC 2023"}
            (ctx.fmt/stringify {:a #inst "2023-10-01T12:00:00Z"})))
 

--- a/mokujin/test/mokujin/context/format_test.clj
+++ b/mokujin/test/mokujin/context/format_test.clj
@@ -1,0 +1,29 @@
+(ns mokujin.context.format-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [mokujin.context.format :as ctx.fmt]))
+
+(deftest stringify-test
+  (testing "simple case"
+    (is (= {} (ctx.fmt/stringify {}))))
+
+  (testing "simple case with string keys"
+    (is (= {"a" "b"} (ctx.fmt/stringify {"a" "b"}))))
+
+  (testing "keyword handling, including namespaced kws"
+    (is (= {"a" "b" "c/d" "e"} (ctx.fmt/stringify {:a :b :c/d :e})))
+    (is (= {"a/b" "c/d"} (ctx.fmt/stringify {:a/b :c/d})))
+    (is (= {"a.b/c" "d.e/f"} (ctx.fmt/stringify {:a.b/c :d.e/f}))))
+
+  (testing "collection handling"
+    (is (= {"a" (pr-str [1 2 3])}
+           (ctx.fmt/stringify {:a [1 2 3]}))))
+
+  (testing "other data types"
+    (is (= {"a" "1"} (ctx.fmt/stringify {:a 1})))
+    (is (= {"a" "true"} (ctx.fmt/stringify {:a true})))
+    (is (= {"a" ""} (ctx.fmt/stringify {:a nil})))
+    (is (= {"a" "Sun Oct 01 12:00:00 UTC 2023"}
+           (ctx.fmt/stringify {:a #inst "2023-10-01T12:00:00Z"})))
+
+    (is (= {"huh" "clojure.lang.ExceptionInfo: woah {:a 1, :b 2}"}
+           (ctx.fmt/stringify {:huh (ex-info "woah" {:a 1 :b 2})})))))


### PR DESCRIPTION
Fixes a bug in current context formatter where `nil` and `false` end up being returned as "", rather than their literal value (like `true` does).

Secondly, adds a slower opt-in formatter for context which flattens nested data structures. Example:

```clj
(flatten {:a { :b 1
          :c [2 3]
          :d {:e 4}}})

; => { "a.b" "1"
      "a.c.0" "2"
      "a.c.1" "3"
      "a.d.e" "4"}
```