### PR TITLE
Add log capturing helpers for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,75 @@ alternatively, you can set these properties via JVM options:
 From there, Open Telemetry will automatically capture MDC attributes and attach them to spans, inject trace IDs etc.
 
 
+## Testing
+
+`mokujin-logback` ships with `mokujin.logback.capture`, a small set of helpers for asserting on log events directly in tests. Instead of parsing rendered log output, you get plain Clojure maps with the level, message, MDC, logger name, thread, timestamp, and any logged throwable.
+
+```clojure
+(require '[mokujin.log :as log]
+         '[mokujin.logback.capture :as capture])
+
+(capture/with-captured-logs
+  (log/with-context {:user-id 1}
+    (log/info "hi")))
+;; => [{:level :info
+;;      :message "hi"
+;;      :logger-name "user"
+;;      :thread-name "nREPL-session-..."
+;;      :mdc {"user-id" "1"}
+;;      :throwable nil
+;;      :timestamp #inst "..."}]
+```
+
+### `with-captured-logs`
+
+Attaches an in-memory appender to the root logger for the duration of the body. Captured events are available via `(capture/get-logs)` from within the block.
+
+```clojure
+(deftest notification-logging
+  (capture/with-captured-logs
+    (handle-notification user notification)
+    (is (match? [{:level :info :message "success" :mdc {"user-id" "42"}}]
+                (capture/get-logs)))))
+```
+
+Calling `get-logs` outside of a `with-captured-logs` block throws — captures are scoped to the block, never global.
+
+### `with-root-log-level`
+
+Captures only see events the logger would have emitted, so DEBUG/TRACE messages are dropped if the root logger is configured at INFO. Wrap the body in `with-root-log-level` to temporarily change the root level for the test:
+
+```clojure
+(capture/with-captured-logs
+  (capture/with-root-log-level :debug
+    (log/debug "diagnostic"))
+  (is (match? [{:level :debug :message "diagnostic"}]
+              (capture/get-logs))))
+```
+
+The previous level is restored on exit, even if the body throws.
+
+### Asserting on exceptions
+
+`log/error` writes the exception (and its full cause chain) to the captured event under `:throwable`:
+
+```clojure
+(capture/with-captured-logs
+  (let [cause   (ex-info "underlying" {:why :testing})
+        wrapped (ex-info "boom" {:fail true} cause)]
+    (log/error wrapped "something failed" {:request-id "abc"}))
+  (is (match? [{:level :error
+                :message "something failed"
+                :mdc {"request-id" "abc"}
+                :throwable {:class-name "clojure.lang.ExceptionInfo"
+                            :message "boom"
+                            :cause {:class-name "clojure.lang.ExceptionInfo"
+                                    :message "underlying"}}}]
+              (capture/get-logs))))
+```
+
+When no exception is logged, `:throwable` is `nil`.
+
 
 ## TODO
 

--- a/mokujin-logback/deps.edn
+++ b/mokujin-logback/deps.edn
@@ -13,6 +13,7 @@
 
            :test {:extra-paths ["dev-resources" "test"]
                   :extra-deps {cheshire/cheshire {:mvn/version "6.1.0"}
+                               nubank/matcher-combinators {:mvn/version "3.9.2"}
                                lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
 
            :run-tests {:main-opts ["-m" "kaocha.runner"]}

--- a/mokujin-logback/deps.edn
+++ b/mokujin-logback/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
- :deps {org.clojure/data.xml {:mvn/version "0.2.0-alpha10"}
-        ch.qos.logback/logback-classic {:mvn/version "1.5.24"
+ :deps {org.clojure/data.xml {:mvn/version "0.2.0-alpha11"}
+        ch.qos.logback/logback-classic {:mvn/version "1.5.32"
                                         :exclusions [org.slf4j/slf4j-api]}
         net.logstash.logback/logstash-logback-encoder {:mvn/version "9.0"}}
 
@@ -12,12 +12,12 @@
                               org.clojars.lukaszkorecki/mokujin {:local/root "../mokujin"}}}
 
            :test {:extra-paths ["dev-resources" "test"]
-                  :extra-deps {cheshire/cheshire {:mvn/version "6.1.0"}
-                               nubank/matcher-combinators {:mvn/version "3.9.2"}
+                  :extra-deps {cheshire/cheshire {:mvn/version "6.2.0"}
+                               nubank/matcher-combinators {:mvn/version "3.10.0"}
                                lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
 
            :run-tests {:main-opts ["-m" "kaocha.runner"]}
 
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.12"}
-                          slipset/deps-deploy {:mvn/version "0.2.2"}}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.13"}
+                          slipset/deps-deploy {:mvn/version "0.2.3"}}
                    :ns-default build}}}

--- a/mokujin-logback/src/mokujin/logback.clj
+++ b/mokujin-logback/src/mokujin/logback.clj
@@ -4,6 +4,7 @@
   of the Logback configuration, it just provides a way to configure it at runtime and optionally with EDN data.
   "
   (:require
+   [clojure.set :as set]
    [mokujin.logback.config :as config])
   (:import
    [ch.qos.logback.classic Level Logger LoggerContext]
@@ -93,9 +94,12 @@
    :error Level/ERROR
    :trace Level/TRACE})
 
+(def level->keyword
+  (set/map-invert levels))
+
 (defn set-level!
   "Set logging level dynamically - can be used to change logging level at runtime
-  If only level (a kewyord of the levels map) is provided, it will set the level for the root logger
+  If only level (a keyword of the levels map) is provided, it will set the level for the root logger
   if name and level are provided, it will set the level for the named logger.
   "
   ([level]
@@ -103,3 +107,16 @@
   ([name level]
    (let [{:keys [logger]} (get-named-logger-and-context name)]
      (.setLevel ^Logger logger ^Level (get levels level :info)))))
+
+(defn get-level
+  "Get current logging level as a keyword.
+  With no args, get the level for the root logger
+  With a name, get the level for the named logger.
+  "
+  ([]
+   (get-level Logger/ROOT_LOGGER_NAME))
+  ([name]
+   (let [{:keys [logger]} (get-named-logger-and-context name)]
+     (get level->keyword
+          (.getLevel ^Logger logger)
+          :off))))

--- a/mokujin-logback/src/mokujin/logback.clj
+++ b/mokujin-logback/src/mokujin/logback.clj
@@ -109,14 +109,15 @@
      (.setLevel ^Logger logger ^Level (get levels level :info)))))
 
 (defn get-level
-  "Get current logging level as a keyword.
-  With no args, get the level for the root logger
-  With a name, get the level for the named logger.
+  "Get the effective logging level as a keyword.
+  With no args, get the level for the root logger.
+  With a name, get the level for the named logger - if the named logger has no
+  level set directly, the level inherited from its parent is returned.
   "
   ([]
    (get-level Logger/ROOT_LOGGER_NAME))
   ([name]
    (let [{:keys [logger]} (get-named-logger-and-context name)]
      (get level->keyword
-          (.getLevel ^Logger logger)
+          (.getEffectiveLevel ^Logger logger)
           :off))))

--- a/mokujin-logback/src/mokujin/logback.clj
+++ b/mokujin-logback/src/mokujin/logback.clj
@@ -95,6 +95,9 @@
    :trace Level/TRACE})
 
 (def level->keyword
+  "Inverse of `levels` - maps a Logback `Level` instance back to the Mokujin
+  level keyword. Public so downstream tooling (e.g. `mokujin.logback.capture`)
+  can translate logging events without re-deriving the mapping."
   (set/map-invert levels))
 
 (defn set-level!

--- a/mokujin-logback/src/mokujin/logback/capture.clj
+++ b/mokujin-logback/src/mokujin/logback/capture.clj
@@ -6,6 +6,8 @@
    [ch.qos.logback.classic Logger LoggerContext]
    [org.slf4j LoggerFactory]))
 
+(set! *warn-on-reflection* true)
+
 (defn ^:private get-root-logger []
   (let [logger-context (LoggerFactory/getILoggerFactory)]
     (LoggerContext/.getLogger logger-context ^String Logger/ROOT_LOGGER_NAME)))

--- a/mokujin-logback/src/mokujin/logback/capture.clj
+++ b/mokujin-logback/src/mokujin/logback/capture.clj
@@ -1,7 +1,7 @@
 (ns mokujin.logback.capture
   (:require [mokujin.logback])
   (:import
-   [ch.qos.logback.classic.spi ILoggingEvent]
+   [ch.qos.logback.classic.spi ILoggingEvent IThrowableProxy]
    [ch.qos.logback.core AppenderBase Appender]
    [ch.qos.logback.classic Logger LoggerContext]
    [org.slf4j LoggerFactory]))
@@ -9,6 +9,12 @@
 (defn ^:private get-root-logger []
   (let [logger-context (LoggerFactory/getILoggerFactory)]
     (LoggerContext/.getLogger logger-context ^String Logger/ROOT_LOGGER_NAME)))
+
+(defn ^:private throwable-proxy->map [^IThrowableProxy t]
+  (when t
+    (cond-> {:class-name (.getClassName t)
+             :message (.getMessage t)}
+      (.getCause t) (assoc :cause (throwable-proxy->map (.getCause t))))))
 
 (defn atom-appender [logs]
   (let [appender (proxy [AppenderBase] []
@@ -19,6 +25,7 @@
                              :message (.getFormattedMessage ev)
                              :logger-name (.getLoggerName ev)
                              :mdc (into {} (.getMDCPropertyMap ev))
+                             :throwable (throwable-proxy->map (.getThrowableProxy ev))
                              :timestamp (.getInstant ev)})))]
     (AppenderBase/.setContext appender (LoggerFactory/getILoggerFactory))
     (AppenderBase/.setName appender "AtomAppender")
@@ -33,7 +40,8 @@
       (Logger/.addAppender logger appender)
       (f)
       (finally
-        (Logger/.detachAppender logger appender)))))
+        (Logger/.detachAppender logger appender)
+        (Appender/.stop appender)))))
 
 (defmacro with-captured-logs [& body]
   `(let [logs# (atom [])]

--- a/mokujin-logback/src/mokujin/logback/capture.clj
+++ b/mokujin-logback/src/mokujin/logback/capture.clj
@@ -1,0 +1,57 @@
+(ns mokujin.logback.capture
+  (:require [mokujin.logback])
+  (:import
+   [ch.qos.logback.classic.spi ILoggingEvent]
+   [ch.qos.logback.core AppenderBase Appender]
+   [ch.qos.logback.classic Logger LoggerContext]
+   [org.slf4j LoggerFactory]))
+
+(defn ^:private get-root-logger []
+  (let [logger-context (LoggerFactory/getILoggerFactory)]
+    (LoggerContext/.getLogger logger-context ^String Logger/ROOT_LOGGER_NAME)))
+
+(defn atom-appender [logs]
+  (let [appender (proxy [AppenderBase] []
+                   (append [^ILoggingEvent ev]
+                     (swap! logs conj
+                            {:thread-name (.getThreadName ev)
+                             :level (get mokujin.logback/level->keyword (.getLevel ev) :off)
+                             :message (.getFormattedMessage ev)
+                             :logger-name (.getLoggerName ev)
+                             :mdc (into {} (.getMDCPropertyMap ev))
+                             :timestamp (.getInstant ev)})))]
+    (AppenderBase/.setContext appender (LoggerFactory/getILoggerFactory))
+    (AppenderBase/.setName appender "AtomAppender")
+    appender))
+
+(def ^:dynamic *logs* nil)
+
+(defn do-with-appender [^Appender appender f]
+  (let [logger (get-root-logger)]
+    (try
+      (Appender/.start appender)
+      (Logger/.addAppender logger appender)
+      (f)
+      (finally
+        (Logger/.detachAppender logger appender)))))
+
+(defmacro with-captured-logs [& body]
+  `(let [logs# (atom [])]
+     (binding [*logs* logs#]
+       (do-with-appender (atom-appender logs#)
+                         (fn* ^:once [] ~@body)))))
+
+(defmacro with-root-log-level [level & body]
+  `(let [prev-level# (mokujin.logback/get-level)
+         level# ~level]
+     (try
+       (mokujin.logback/set-level! level#)
+       ~@body
+       (finally
+         (mokujin.logback/set-level! prev-level#)))))
+
+(defn get-logs []
+  (if *logs*
+    @*logs*
+    (throw (ex-info "Call get-logs inside of a with-captured-logs block!" {}))))
+

--- a/mokujin-logback/src/mokujin/logback/capture.clj
+++ b/mokujin-logback/src/mokujin/logback/capture.clj
@@ -9,7 +9,7 @@
 (set! *warn-on-reflection* true)
 
 (defn ^:private get-root-logger []
-  (let [logger-context (LoggerFactory/getILoggerFactory)]
+  (let [^LoggerContext logger-context (LoggerFactory/getILoggerFactory)]
     (LoggerContext/.getLogger logger-context ^String Logger/ROOT_LOGGER_NAME)))
 
 (defn ^:private throwable-proxy->map [^IThrowableProxy t]
@@ -29,7 +29,7 @@
                              :mdc (into {} (.getMDCPropertyMap ev))
                              :throwable (throwable-proxy->map (.getThrowableProxy ev))
                              :timestamp (.getInstant ev)})))]
-    (AppenderBase/.setContext appender (LoggerFactory/getILoggerFactory))
+    (AppenderBase/.setContext appender ^LoggerContext (LoggerFactory/getILoggerFactory))
     (AppenderBase/.setName appender "AtomAppender")
     appender))
 

--- a/mokujin-logback/src/mokujin/logback/capture.clj
+++ b/mokujin-logback/src/mokujin/logback/capture.clj
@@ -1,4 +1,15 @@
 (ns mokujin.logback.capture
+  "Test helpers for capturing logging events in-process.
+
+  Attach an in-memory appender to the root logger for the duration of a
+  block via `with-captured-logs`, then assert against the captured events
+  with `get-logs`. Each captured event is a plain Clojure map with the
+  level, message, MDC, logger name, thread, timestamp, and any logged
+  throwable (with a recursive `:cause` chain), so tests can assert on
+  structured fields directly instead of parsing rendered log output.
+
+  Use `with-root-log-level` to temporarily lower the root level when the
+  events you want to assert on would otherwise be filtered out."
   (:require [mokujin.logback])
   (:import
    [ch.qos.logback.classic.spi ILoggingEvent IThrowableProxy]
@@ -18,7 +29,8 @@
              :message (.getMessage t)}
       (.getCause t) (assoc :cause (throwable-proxy->map (.getCause t))))))
 
-(defn atom-appender [logs]
+(defn -atom-appender
+  [logs]
   (let [appender (proxy [AppenderBase] []
                    (append [^ILoggingEvent ev]
                      (swap! logs conj
@@ -33,9 +45,14 @@
     (AppenderBase/.setName appender "AtomAppender")
     appender))
 
-(def ^:dynamic *logs* nil)
+(def ^:dynamic *logs*
+  "Atom holding the vector of captured log maps for the current
+  `with-captured-logs` block. `nil` outside of a block; `get-logs`
+  dereferences this and throws when unbound."
+  nil)
 
-(defn do-with-appender [^Appender appender f]
+(defn -do-with-appender
+  [^Appender appender f]
   (let [logger (get-root-logger)]
     (try
       (Appender/.start appender)
@@ -45,13 +62,28 @@
         (Logger/.detachAppender logger appender)
         (Appender/.stop appender)))))
 
-(defmacro with-captured-logs [& body]
+(defmacro with-captured-logs
+  "Capture log events emitted during `body`. Inside the block,
+  `(get-logs)` returns the events captured so far as a vector of maps.
+
+  Captured events are scoped to the dynamic extent of the block.Events
+  filtered out by the root logger's level are not captured; use
+  `with-root-log-level` to change the log level threshold. "
+  [& body]
   `(let [logs# (atom [])]
      (binding [*logs* logs#]
-       (do-with-appender (atom-appender logs#)
-                         (fn* ^:once [] ~@body)))))
+       (-do-with-appender (-atom-appender logs#)
+                          (fn* ^:once [] ~@body)))))
 
-(defmacro with-root-log-level [level & body]
+(defmacro with-root-log-level
+  "Set the root logger's level to `level` (a keyword from
+  `mokujin.logback/levels`) for the dynamic extent of `body`, restoring
+  the previous level on exit even if `body` throws.
+
+  Useful inside `with-captured-logs` when the events under test sit
+  below the configured root level (e.g. asserting on `:debug` output in
+  a project whose default level is `:info`)."
+  [level & body]
   `(let [prev-level# (mokujin.logback/get-level)
          level# ~level]
      (try
@@ -60,7 +92,10 @@
        (finally
          (mokujin.logback/set-level! prev-level#)))))
 
-(defn get-logs []
+(defn get-logs
+  "Return the vector of log events captured so far in the surrounding
+  `with-captured-logs` block."
+  []
   (if *logs*
     @*logs*
     (throw (ex-info "Call get-logs inside of a with-captured-logs block!" {}))))

--- a/mokujin-logback/test/mokujin/logback/capture_test.clj
+++ b/mokujin-logback/test/mokujin/logback/capture_test.clj
@@ -9,8 +9,9 @@
 (deftest capture-logs-test
   (testing "captures logs from mokujin"
     (capture/with-captured-logs
-      (log/info "This is a test")
-      (log/debug "Oh, hello")
+      (capture/with-root-log-level :debug
+        (log/info "This is a test")
+        (log/debug "Oh, hello"))
       (is (match? [{:level :info
                     :message "This is a test"
                     :logger-name "mokujin.logback.capture-test"

--- a/mokujin-logback/test/mokujin/logback/capture_test.clj
+++ b/mokujin-logback/test/mokujin/logback/capture_test.clj
@@ -35,6 +35,23 @@
                     :mdc {"context-thing" "stringified"}
                     :timestamp inst?}]
                   (capture/get-logs)))))
+  (testing "captures throwables logged via log/error"
+    (capture/with-captured-logs
+      (let [cause (ex-info "underlying" {:why :testing})
+            wrapped (ex-info "boom" {:fail true} cause)]
+        (log/error wrapped "something failed" {:request-id "abc"}))
+      (is (match? [{:level :error
+                    :message "something failed"
+                    :mdc {"request-id" "abc"}
+                    :throwable {:class-name "clojure.lang.ExceptionInfo"
+                                :message "boom"
+                                :cause {:class-name "clojure.lang.ExceptionInfo"
+                                        :message "underlying"}}}]
+                  (capture/get-logs)))))
+  (testing "throwable is nil when no exception was logged"
+    (capture/with-captured-logs
+      (log/info "plain message")
+      (is (match? [{:throwable nil}] (capture/get-logs)))))
   (testing "warns with calling get-logs outside of block"
     (is (thrown-with-msg? Exception #"Call get-logs inside of a with-captured-logs block!"
                           (capture/get-logs))))

--- a/mokujin-logback/test/mokujin/logback/capture_test.clj
+++ b/mokujin-logback/test/mokujin/logback/capture_test.clj
@@ -1,0 +1,51 @@
+(ns mokujin.logback.capture-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [matcher-combinators.test :refer [match?]]
+   [mokujin.log :as log]
+   [mokujin.logback]
+   [mokujin.logback.capture :as capture]))
+
+(deftest capture-logs-test
+  (testing "captures logs from mokujin"
+    (capture/with-captured-logs
+      (log/info "This is a test")
+      (log/debug "Oh, hello")
+      (is (match? [{:level :info
+                    :message "This is a test"
+                    :logger-name "mokujin.logback.capture-test"
+                    :thread-name string?
+                    :mdc {}
+                    :timestamp inst?}
+                   {:level :debug
+                    :message "Oh, hello"
+                    :logger-name "mokujin.logback.capture-test"
+                    :thread-name string?
+                    :mdc {}
+                    :timestamp inst?}]
+                  (capture/get-logs)))))
+  (testing "captures MDC context"
+    (capture/with-captured-logs
+      (log/with-context {:context-thing :stringified}
+        (log/warn "This is a test"))
+      (is (match? [{:level :warn
+                    :message "This is a test"
+                    :logger-name "mokujin.logback.capture-test"
+                    :thread-name string?
+                    :mdc {"context-thing" "stringified"}
+                    :timestamp inst?}]
+                  (capture/get-logs)))))
+  (testing "warns with calling get-logs outside of block"
+    (is (thrown-with-msg? Exception #"Call get-logs inside of a with-captured-logs block!"
+                          (capture/get-logs))))
+  (testing "Only captures logs that are within the current level"
+    (capture/with-captured-logs
+      (capture/with-root-log-level :warn
+        (log/info "This should be missing")
+        (log/warn "This should be present"))
+      (log/info "This should also be present")
+      (is (match? [{:level :warn
+                    :message "This should be present"}
+                   {:level :info
+                    :message "This should also be present"}]
+                  (capture/get-logs))))))

--- a/mokujin-logback/test/mokujin/logback_test.clj
+++ b/mokujin-logback/test/mokujin/logback_test.clj
@@ -1,0 +1,26 @@
+(ns mokujin.logback-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [mokujin.logback :as logback]))
+
+(deftest get-level-test
+  (testing "returns the root logger level when called with no args"
+    (let [original (logback/get-level)]
+      (try
+        (logback/set-level! :warn)
+        (is (= :warn (logback/get-level)))
+        (finally
+          (logback/set-level! original)))))
+
+  (testing "named logger inherits its parent level when none is set directly"
+    (let [logger-name "mokujin.logback-test.inherits"
+          original-root (logback/get-level)]
+      (try
+        (logback/set-level! :warn)
+        (is (= :warn (logback/get-level logger-name))
+            "no direct level → effective level walks up to root")
+        (logback/set-level! logger-name :debug)
+        (is (= :debug (logback/get-level logger-name))
+            "direct level wins over inherited")
+        (finally
+          (logback/set-level! original-root))))))

--- a/mokujin/deps.edn
+++ b/mokujin/deps.edn
@@ -11,12 +11,12 @@
 
            :test {:extra-paths ["dev-resources" "test"]
                   :extra-deps {org.clojars.lukaszkorecki/mokujin-logback {:local/root "../mokujin-logback"}
-                               cheshire/cheshire {:mvn/version "6.1.0"}
-                               nubank/matcher-combinators {:mvn/version "3.9.2"}
+                               cheshire/cheshire {:mvn/version "6.2.0"}
+                               nubank/matcher-combinators {:mvn/version "3.10.0"}
                                lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
 
            :run-tests {:main-opts ["-m" "kaocha.runner"]}
 
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.12"}
-                          slipset/deps-deploy {:mvn/version "0.2.2"}}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.13"}
+                          slipset/deps-deploy {:mvn/version "0.2.3"}}
                    :ns-default build}}}

--- a/mokujin/src/mokujin/log.clj
+++ b/mokujin/src/mokujin/log.clj
@@ -5,7 +5,7 @@
    (org.slf4j MDC)))
 
 (defn- ->str
-  [val] ^String
+  ^String [val]
   (if val
     (if (keyword? val)
       ;; all of these are quite slow


### PR DESCRIPTION
## Summary
- Adds `mokujin.logback.capture` with `with-captured-logs` / `with-root-log-level` so consumers can assert directly on logging events in tests instead of parsing rendered output.
- Captured events expose level, message, MDC, logger name, thread, timestamp, and `:throwable` (with a recursive `:cause` chain) so `(log/error ex "msg" ctx)` can be asserted end-to-end.
- Adds `mokujin.logback/get-level` (returns the effective level as a keyword) and a public `level->keyword` map so the capture appender can translate Logback `Level` instances without re-deriving the mapping.
- Drive-by fix: corrects the `^String` return-type hint position on `mokujin.log/->str` (it was attached to the body, not the function).